### PR TITLE
fix(docker-build): Prevent undefined-latest tag when bulding a non-existent image

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
-  "extends": [
-    "oclif",
-    "oclif-typescript"
-  ]
+    "extends": ["oclif", "oclif-typescript"],
+    "rules": {
+        "semi": [2, "always"],
+        "quotes": [1, "single"],
+        "indent": [1, 4],
+        "object-curly-spacing": [1, "always"]
+    }
 }

--- a/src/modules/shared/base-commands/build-image-workflow.base-command.ts
+++ b/src/modules/shared/base-commands/build-image-workflow.base-command.ts
@@ -82,10 +82,11 @@ export abstract class BuildImageWorkflowBaseCommand extends BaseCommand {
             dockerBuildFlags: flags.dockerBuildFlags,
         });
 
+        const additionalTags = flags.tag ? [projectVersion, `${flags.tag}-latest`] : [projectVersion];
         // Push the image to the registry
         await pushDockerImage({
             localImageName,
-            tags: this.getTags(hash, flags).concat([projectVersion, `${flags.tag}-latest`]),
+            tags: [...this.getTags(hash, flags), ...additionalTags],
             imageName: flags.imageName,
             registry: flags.registry,
             dryRun: flags.dryRun,


### PR DESCRIPTION
## Problem
* Logic for existing images checks for if tag is undefined but not when pushing a new image

## Fix
* Check if tag is defined when pushing a new image and only append if it is defined